### PR TITLE
Get PHP 7.1 from the archive

### DIFF
--- a/php-appveyor.psm1
+++ b/php-appveyor.psm1
@@ -55,7 +55,7 @@ function InstallPhp {
 	Write-Debug "Install PHP v${FullVersion}"
 
 	$ReleasesPart = "releases"
-	if ([System.Convert]::ToDecimal($Version) -lt 7.1) {
+	if ([System.Convert]::ToDecimal($Version) -lt 7.2) {
 		$ReleasesPart = "releases/archives"
 	}
 
@@ -92,7 +92,7 @@ function InstallPhpDevPack {
 	Write-Debug "Install PHP Dev for PHP v${Version}"
 
 	$ReleasesPart = "releases"
-	if ([System.Convert]::ToDecimal($PhpVersion) -lt 7.1) {
+	if ([System.Convert]::ToDecimal($PhpVersion) -lt 7.2) {
 		$ReleasesPart = "releases/archives"
 	}
 


### PR DESCRIPTION
Since PHP 7.1 is now end-of-life, it's no longer available in [windows.php.net/downloads/releases](https://windows.php.net/downloads/releases/).

This PR bumps the version below which to use the `archive/` folder to 7.2.